### PR TITLE
fix: delete row on post images when deleting related post

### DIFF
--- a/backend/repository/posts.go
+++ b/backend/repository/posts.go
@@ -312,6 +312,12 @@ func (p *PostRepository) DeletePostByID(postID int) error {
 		return err
 	}
 
+	_, err = tx.Exec(`DELETE FROM post_images WHERE post_id = ?;`, postID)
+
+	if err != nil {
+		return err
+	}
+
 	if err := tx.Commit(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What?   
Deleting Post Images when delete post occured

## Why?  
Make more space on db

## How?  
Deleting row on post images table when deleting related post

## Type of change  
- [x] Enhancement