### PR TITLE
fix: fix create comment

### DIFF
--- a/backend/api/comments.go
+++ b/backend/api/comments.go
@@ -86,7 +86,7 @@ func (api API) CreateComment(c *gin.Context) {
 	if createCommentRequest.ParentCommentID != nil {
 		authorId, err = api.commentRepo.FetchCommentAuthorId(*createCommentRequest.ParentCommentID)
 	} else {
-		authorId, err = api.postRepo.FetchAuthorIDByPostID(*createCommentRequest.ParentCommentID)
+		authorId, err = api.postRepo.FetchAuthorIDByPostID(createCommentRequest.PostID)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## What?   
I fixed create comment when parent comment id is null.

## Why?  
Client should be able to make comments without parent comment id.

## How?  
By using post id to get author id.

## Type of change  
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature 