### PR TITLE
refactor: remove author id from CUD post parameter

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -76,7 +76,7 @@ func NewAPI(
 		postRouter.POST("/", api.createPost)
 		postRouter.POST("/images/:id", api.uploadPostImages)
 		postRouter.PUT("/", api.updatePost)
-		postRouter.DELETE("/", api.deletePost)
+		postRouter.DELETE("/:id", api.deletePost)
 	}
 
 	router.GET("/api/comments", api.ReadAllComment)


### PR DESCRIPTION
## What?   
Remove author ID from CUD post parameter

## Why?  
Because we can extract the ID from the token, so we no longers need the author id parameter

## How?  
Extract the authorID from the token

## Type of change  
- [x] Enhancement