### PR TITLE
feat: add is author and is like in get questionnaire response

### DIFF
--- a/backend/repository/entity.go
+++ b/backend/repository/entity.go
@@ -38,6 +38,8 @@ type Questionnaire struct {
 	Reward       string     `json:"reward"`
 	TotalLike    int        `json:"total_like"`
 	TotalComment int        `json:"total_comment"`
+	IsLike       bool       `json:"is_like"`
+	IsAuthor     bool       `json:"is_author"`
 }
 
 type Notification struct {


### PR DESCRIPTION
## What?   
Add is author and is like in get questionnaire response

## Why?  
Users should know their questionnaires and which questionnaires have been liked.

## How?  
To get is author, we can compare the user id and author id from questionnaire data.
Meanwhile, to get is like, we can check data in the post likes table using the post id and user id.

## Type of change  
- [x] Enhancement