### PR TITLE
feat: add is author and is like in get comment response

### DIFF
--- a/backend/api/comments.go
+++ b/backend/api/comments.go
@@ -33,7 +33,16 @@ func (api *API) ReadAllComment(c *gin.Context) {
 		return
 	}
 
-	comments, err := api.commentRepo.SelectAllCommentsByPostID(postID)
+	userID := -1
+	if c.GetHeader("Authorization") != "" {
+		userID, err = api.getUserIdFromToken(c)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	comments, err := api.commentRepo.SelectAllCommentsByPostID(userID, postID)
 	if err != nil {
 		c.AbortWithStatusJSON(
 			http.StatusInternalServerError,

--- a/backend/repository/entity.go
+++ b/backend/repository/entity.go
@@ -12,6 +12,8 @@ type Comment struct {
 	AuthorName      string     `json:"author_name" db:"author_name"`
 	TotalLike       int        `json:"total_like"`
 	TotalReply      int        `json:"total_reply"`
+	IsLike          bool       `json:"is_like"`
+	IsAuthor        bool       `json:"is_author"`
 	Reply           []Comment  `json:"reply"`
 }
 


### PR DESCRIPTION
## What?   
Add is author and is like in get comment response.

## Why?  
Users should know their comments and which comments have been liked.

## How?  
To get is author, we can compare the user id and author id from comment data. Meanwhile, to get is like, we can check data in the comment likes table using the comment id and user id.

## Type of change  
- [x] Enhancement