### PR TITLE
fix: fix loop image (only 1 image showed)

### DIFF
--- a/frontend/src/components/Post Content/PostContent.jsx
+++ b/frontend/src/components/Post Content/PostContent.jsx
@@ -223,12 +223,12 @@ const PostContent = ({ data, page, type }) => {
           </p>
           {type === 'detail' &&
             page === 'forum' &&
-            data.images[0] &&
+            data.images &&
             data.images.map((image, index) => {
               return (
                 <img
                   key={index}
-                  src={`http://167.172.84.216/${data.images[0].url}`}
+                  src={`http://167.172.84.216/${image.url}`}
                   alt='Description'
                 />
               );


### PR DESCRIPTION
## What?   
Fix when a post has more than 1 image, it only shows 1 image and then looped as many as the post's images

## Why?  
So all post's images will be displayed

## How?  
Fix code on the front-end (PostContent file)

## Type of change  
- [x] Bug fix